### PR TITLE
Updated Scala version to 2.11.4

### DIFF
--- a/attributes/attributes.rb
+++ b/attributes/attributes.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-default[:scala][:version]     = "2.11.2"
+default[:scala][:version]     = "2.11.4"
 default[:scala][:url]         = "http://www.scala-lang.org/files/archive/scala-#{node[:scala][:version]}.tgz"
-default[:scala][:checksum]    = "13dd31dff965535f2b3d3075f8283474c212100264071076caf0ca1ea384d256"
+default[:scala][:checksum]    = "000f5a19de78049bc06e33ee98063c7ad3cfd51212df92a8a164af89aeef8084"
 default[:scala][:home]        = "/usr/local/scala"


### PR DESCRIPTION
Updated version and checksum attribute to Scala version 2.11.4

http://scala-lang.org/news/2.11.4
